### PR TITLE
Change __version__ from float to str

### DIFF
--- a/ipy_table.py
+++ b/ipy_table.py
@@ -58,7 +58,7 @@ This project is maintained at http://github.com/epmoyer/ipy_table
 import copy
 
 
-__version__ = 1.13
+__version__ = '1.13'
 
 # Private table object used for interactive mode
 _TABLE = None


### PR DESCRIPTION
Although there isn't an official standard, it seems that `__version__` is typically a `str`. See the discussion at [StackOverflow](http://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package).

I encountered a difficulty with the float `__version__` when using the [%version_information](https://github.com/jrjohansson/version_information/) extension.
