### PR TITLE
Added semicolon in for &nbsp;

### DIFF
--- a/ipy_table.py
+++ b/ipy_table.py
@@ -368,7 +368,7 @@ class IpyTable(object):
         # If cell wrapping is not specified
         if not ('wrap' in cell_style and cell_style['wrap']):
             # Convert all spaces to non-breaking and return
-            text = text.replace(' ', '&nbsp')
+            text = text.replace(' ', '&nbsp;')
         return text
 
     def _split_by_comma(self, comma_delimited_text):


### PR DESCRIPTION
Fix for #19. Certain browsers seem to not care about the missing semi-colon and will render it correctly. Other browsers like Chrome will not interpret &nbsp as a space.
